### PR TITLE
GPII 2064 - Update CentOS VM

### DIFF
--- a/ansible/roles/common/tasks/always.yml
+++ b/ansible/roles/common/tasks/always.yml
@@ -2,13 +2,13 @@
 - name: Ensure root password is right
   user:
     user: root
-    password: vagrant
+    password: $1$4xc3H7HC$c3b.w3EU/o3SUPxuN3PZH0
     update_password: always
 
 - name: Create vagrant user
   user:
     name: vagrant
-    password: vagrant
+    password: $1$4xc3H7HC$c3b.w3EU/o3SUPxuN3PZH0
     update_password: always
     createhome: yes
 
@@ -30,8 +30,13 @@
 - name: Tweak sshd_config
   lineinfile:
     dest: /etc/ssh/sshd_config
-    regexp: ".*UseDNS.*"
-    line: "UseDNS no"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: ".*UseDNS.*"
+      line: "UseDNS no"
+    - regexp: "^PasswordAuthentication.*"
+      line: "PasswordAuthentication no"
 
 - name: Fix slow DNS
   lineinfile:

--- a/http/ks7.cfg
+++ b/http/ks7.cfg
@@ -16,14 +16,15 @@
 # Required settings
 lang en_US.UTF-8
 keyboard us
-rootpw vagrant
+# password = "vagrant"
+rootpw $1$4xc3H7HC$c3b.w3EU/o3SUPxuN3PZH0
 authconfig --enableshadow --enablemd5
 timezone UTC
 
 # Optional settings
 install
 cdrom
-user --name=vagrant --plaintext --password vagrant
+user --name=vagrant --iscrypted --password $1$4xc3H7HC$c3b.w3EU/o3SUPxuN3PZH0
 unsupported_hardware
 network --bootproto=dhcp
 firewall --disabled

--- a/http/ks7.cfg
+++ b/http/ks7.cfg
@@ -25,6 +25,7 @@ timezone UTC
 install
 cdrom
 user --name=vagrant --iscrypted --password $1$4xc3H7HC$c3b.w3EU/o3SUPxuN3PZH0
+repo --name=updates --mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates
 unsupported_hardware
 network --bootproto=dhcp
 firewall --disabled

--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -4,6 +4,12 @@
 #echo "==> Pausing for ${CLEANUP_PAUSE} seconds..."
 #sleep ${CLEANUP_PAUSE}
 
+echo "==> Removing old kernels"
+yum install -y yum-utils
+package-cleanup -y --oldkernels --count=1
+yum remove -y yum-utils
+yum autoremove -y
+
 echo "==> Cleaning up temporary network addresses"
 # Make sure udev doesn't block our network
 if grep -q -i "release 6" /etc/redhat-release ; then


### PR DESCRIPTION
These are the changes that comes with the version 0.1.1 of the CentOS VM.

 * Save some megs uninstalling old kernels.
 * Update the Vagrant password, the Ansible role was setting the a plain text as password in the shadow file so it wasn't possible to access with vagrant/vagrant at the console terminal.
 * Update the Vagrant role to always run at building time.
 * Use 'update' repository from the beginning of installation to avoid the download of old packages and to update them later.