### PR TITLE
Add CentOS 7.8

### DIFF
--- a/centos7.json
+++ b/centos7.json
@@ -1,9 +1,8 @@
 {
   "builders": [
     {
-      "iso_checksum": "9bba3da2876cb9fcf6c28fb636bcbd01832fe6d84cd7445fa58e44e569b3b4fe",
-      "iso_checksum_type": "sha256",
-      "iso_urls": "https://mirror.csclub.uwaterloo.ca/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-DVD-1908.iso",
+      "iso_checksum": "sha256:087a5743dc6fd6706d9b961b8147423ddc029451b938364c760d75440eb7be14",
+      "iso_urls": "https://mirrors.rit.edu/centos/7.8.2003/isos/x86_64/CentOS-7-x86_64-DVD-2003.iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/centos7-kickstart.cfg<enter>"
       ],

--- a/centos7.json
+++ b/centos7.json
@@ -49,7 +49,6 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash -eux '{{.Path}}'",
       "scripts": [
         "scripts/sshd.sh",
-        "scripts/update.sh",
         "scripts/vagrant.sh",
         "scripts/docker.sh",
         "scripts/systemd.sh",

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -eux
-
-echo "==> Applying updates"
-yum -y update
-
-echo "==> Rebooting the machine..."
-systemctl stop sshd.service
-nohup shutdown -r now < /dev/null > /dev/null 2>&1 &
-exit 0


### PR DESCRIPTION
The update.sh script is removed because the updates repo is already using during installation so trying to update again is a no-op.